### PR TITLE
Fix 3 code scanning alerts

### DIFF
--- a/lib/insecurity.ts
+++ b/lib/insecurity.ts
@@ -133,6 +133,9 @@ export const redirectAllowlist = new Set([
 ])
 
 export const isRedirectAllowed = (url: string) => {
+  if (typeof url !== 'string') {
+    return false
+  }
   let allowed = false
   for (const allowedUrl of redirectAllowlist) {
     allowed = allowed || url.includes(allowedUrl) // vuln-code-snippet vuln-line redirectChallenge

--- a/routes/redirect.ts
+++ b/routes/redirect.ts
@@ -12,8 +12,8 @@ const security = require('../lib/insecurity')
 
 module.exports = function performRedirect () {
   return ({ query }: Request, res: Response, next: NextFunction) => {
-    const toUrl: string = query.to as string
-    if (security.isRedirectAllowed(toUrl)) {
+    const toUrl = Array.isArray(query.to) ? query.to[0] : query.to
+    if (typeof toUrl === 'string' && security.isRedirectAllowed(toUrl)) {
       challengeUtils.solveIf(challenges.redirectCryptoCurrencyChallenge, () => { return toUrl === 'https://explorer.dash.org/address/Xr556RzuwX6hg5EGpkybbv5RanJoZN17kW' || toUrl === 'https://blockchain.info/address/1AbKfgvw9psQ41NbLi8kufDQTezwG8DRZm' || toUrl === 'https://etherscan.io/address/0x0f933ab9fcaaa782d0279c300d73750e1311eae6' })
       challengeUtils.solveIf(challenges.redirectChallenge, () => { return isUnintendedRedirect(toUrl) })
       res.redirect(toUrl)

--- a/routes/showProductReviews.ts
+++ b/routes/showProductReviews.ts
@@ -31,7 +31,7 @@ module.exports = function productReviews () {
 
     // Measure how long the query takes, to check if there was a nosql dos attack
     const t0 = new Date().getTime()
-    db.reviewsCollection.find({ $where: 'this.product == ' + id }).then((reviews: Review[]) => {
+    db.reviewsCollection.find({ product: id }).then((reviews: Review[]) => {
       const t1 = new Date().getTime()
       challengeUtils.solveIf(challenges.noSqlCommandChallenge, () => { return (t1 - t0) > 2000 })
       const user = security.authenticatedUsers.from(req)


### PR DESCRIPTION
Fixes 3 code scanning alerts:
- https://github.com/ghas-bootcamp-2024-12-27-cloudlabs146/juice-shop/security/code-scanning/16
To fix the problem, we need to ensure that the `query.to` parameter is a string before using it in the `isRedirectAllowed` function. This can be done by adding a type check and handling the case where the parameter is not a string. Specifically, we will:
  1. Check the type of `query.to` in `routes/redirect.ts` before passing it to `isRedirectAllowed`.
  2. Modify the `isRedirectAllowed` function in `lib/insecurity.ts` to handle cases where the input is not a string.
  


- https://github.com/ghas-bootcamp-2024-12-27-cloudlabs146/juice-shop/security/code-scanning/7



- https://github.com/ghas-bootcamp-2024-12-27-cloudlabs146/juice-shop/security/code-scanning/6
To fix the problem, we need to avoid directly including user input in the MongoDB query string. Instead, we should use parameterized queries or other safe methods to include user input in the query. In this case, we can use the MongoDB query object to safely include the `id` parameter.

  We will modify the query to use a parameterized approach, ensuring that the `id` is properly handled as a value rather than part of the query string. This will prevent any potential code injection.
  


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
