### PR TITLE
Fix code scanning alert no. 7: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -14,7 +14,7 @@ module.exports = function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : req.params.id
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Fixes [https://github.com/ghas-bootcamp-2024-12-27-cloudlabs146/juice-shop/security/code-scanning/7](https://github.com/ghas-bootcamp-2024-12-27-cloudlabs146/juice-shop/security/code-scanning/7)

To fix the problem, we should avoid using the `$where` operator with user input. Instead, we can use a parameterized query to safely include the user-provided `id` in the MongoDB query. This approach ensures that the input is treated as a value rather than executable code, mitigating the risk of code injection.

We will replace the `$where` query with a standard query using the `orderId` field. This change will be made on line 17 of the `routes/trackOrder.ts` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
